### PR TITLE
Apache 2.4.62 w/ improve SSL security

### DIFF
--- a/bin/apache2.4.62/conf/extra/httpd-ssl.conf
+++ b/bin/apache2.4.62/conf/extra/httpd-ssl.conf
@@ -79,7 +79,7 @@ SSLEngine on
 #   Recent OpenSSL snapshots include Elliptic Curve Cryptograhpy (ECC)
 #   cipher suites (see RFC 4492) as part of "ALL". Edit this line
 #   if you need to disable any of those ciphers.
-SSLCipherSuite ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP:+eNULL
+SSLCipherSuite ALL:!ADH:!EXPORT56:+HIGH:+MEDIUM:+LOW:!SSLv2:!SSLv3:+EXP:+eNULL
 
 #   Server Certificate:
 #   Point SSLCertificateFile at a PEM encoded certificate.  If

--- a/bin/apache2.4.62/conf/extra/httpd-ssl.conf.ber
+++ b/bin/apache2.4.62/conf/extra/httpd-ssl.conf.ber
@@ -1,12 +1,12 @@
 #
 # This is the Apache server configuration file providing SSL support.
 # It contains the configuration directives to instruct the server how to
-# serve pages over an https connection. For detailed information about these 
+# serve pages over an https connection. For detailed information about these
 # directives see <URL:http://httpd.apache.org/docs/trunk/mod/mod_ssl.html>
-# 
+#
 # Do NOT simply read the instructions in here without understanding
 # what they do.  They're here only as hints or reminders.  If you are unsure
-# consult the online docs. You have been warned.  
+# consult the online docs. You have been warned.
 #
 
 #
@@ -28,7 +28,7 @@
 
 
 #
-# When we also provide SSL we have to listen to the 
+# When we also provide SSL we have to listen to the
 # standard HTTP port (see above) and to the HTTPS port
 #
 # Note: Configurations that use IPv6 but not IPv4-mapped addresses need two
@@ -50,7 +50,7 @@ Listen 443
 SSLPassPhraseDialog  builtin
 
 #   Inter-Process Session Cache:
-#   Configure the SSL Session Cache: First the mechanism 
+#   Configure the SSL Session Cache: First the mechanism
 #   to use and second the expiring timeout (in seconds).
 #SSLSessionCache         "dbm:${BEARSAMPP_LIN_PATH}/logs/ssl_scache"
 SSLSessionCache        "shmcb:${BEARSAMPP_LIN_PATH}/logs/ssl_scache(512000)"
@@ -76,10 +76,10 @@ SSLEngine on
 #   SSL Cipher Suite:
 #   List the ciphers that the client is permitted to negotiate.
 #   See the mod_ssl documentation for a complete list.
-#   Recent OpenSSL snapshots include Elliptic Curve Cryptograhpy (ECC) 
+#   Recent OpenSSL snapshots include Elliptic Curve Cryptograhpy (ECC)
 #   cipher suites (see RFC 4492) as part of "ALL". Edit this line
 #   if you need to disable any of those ciphers.
-SSLCipherSuite ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP:+eNULL
+SSLCipherSuite ALL:!ADH:!EXPORT56:+HIGH:+MEDIUM:+LOW:!SSLv2:!SSLv3:+EXP:+eNULL
 
 #   Server Certificate:
 #   Point SSLCertificateFile at a PEM encoded certificate.  If
@@ -174,7 +174,7 @@ SSLCertificateKeyFile "${BEARSAMPP_LIN_PATH}/ssl/localhost.pub"
 #     and no other module can change it.
 #   o OptRenegotiate:
 #     This enables optimized SSL connection renegotiation handling when SSL
-#     directives are used in per-directory context. 
+#     directives are used in per-directory context.
 #SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
 <FilesMatch "\.(cgi|shtml|phtml|php)$">
     SSLOptions +StdEnvVars
@@ -184,7 +184,7 @@ SSLCertificateKeyFile "${BEARSAMPP_LIN_PATH}/ssl/localhost.pub"
     SSLOptions +StdEnvVars
     Options Indexes FollowSymLinks ExecCGI
     AllowOverride None
-    
+
     # START switchOnline tag - Do not replace!
     Require local
     # END switchOnline tag - Do not replace!
@@ -193,7 +193,7 @@ SSLCertificateKeyFile "${BEARSAMPP_LIN_PATH}/ssl/localhost.pub"
     SSLOptions +StdEnvVars
     Options Indexes FollowSymLinks
     AllowOverride All
-    
+
     # START switchOnline tag - Do not replace!
     Require local
     # END switchOnline tag - Do not replace!
@@ -216,7 +216,7 @@ SSLCertificateKeyFile "${BEARSAMPP_LIN_PATH}/ssl/localhost.pub"
 #     alert of the client. This is 100% SSL/TLS standard compliant, but in
 #     practice often causes hanging connections with brain-dead browsers. Use
 #     this only for browsers where you know that their SSL implementation
-#     works correctly. 
+#     works correctly.
 #   Notice: Most problems of broken clients are also related to the HTTP
 #   keep-alive facility, so you usually additionally want to disable
 #   keep-alive for those clients, too. Use variable "nokeepalive" for this.
@@ -233,4 +233,4 @@ BrowserMatch ".*MSIE.*" \
 CustomLog "${BEARSAMPP_LIN_PATH}/logs/apache_sslreq.log" \
           "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 
-</VirtualHost>                                  
+</VirtualHost>

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 bundle.name = apache
 
-bundle.release = 2024.7.20
+bundle.release = 2024.7.23
 
 bundle.type = bins
 bundle.format = 7z

--- a/releases.properties
+++ b/releases.properties
@@ -6,4 +6,4 @@
 2.4.57 = https://github.com/Bearsampp/module-apache/releases/download/2023.6.6/bearsampp-apache-2.4.57-2023.6.6.7z
 2.4.58 = https://github.com/Bearsampp/module-apache/releases/download/2024.3.31/bearsampp-apache-2.4.58-2023.3.31.7z
 2.4.59 = https://github.com/Bearsampp/module-apache/releases/download/2024.4.7/bearsampp-apache-2.4.59-2024.4.7.7z
-2.4.62 = https://github.com/Bearsampp/module-apache/releases/download/2024.7.20/bearsampp-apache-2.4.62-2024.7.20.7z
+2.4.62 = https://github.com/Bearsampp/module-apache/releases/download/2024.7.23/bearsampp-apache-2.4.62-2024.7.23.7z


### PR DESCRIPTION
Disables SSL2 and SSL3 by default as they are insecure methods.